### PR TITLE
Add GitHub Actions workflow to auto-update repository references

### DIFF
--- a/.github/workflows/update-repo-refs.yml
+++ b/.github/workflows/update-repo-refs.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   update-refs:
+    # Skip if the push was made by the GitHub Actions bot
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/update-repo-refs.yml
+++ b/.github/workflows/update-repo-refs.yml
@@ -1,0 +1,49 @@
+name: Update Repository References
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+
+jobs:
+  update-refs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Update repository references
+        run: |
+          BRANCH=${GITHUB_REF#refs/heads/}
+          REPO_OWNER=$(echo $GITHUB_REPOSITORY | cut -d '/' -f1)
+          REPO_NAME=$(echo $GITHUB_REPOSITORY | cut -d '/' -f2)
+          
+          # Update README.md
+          sed -i "s|raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/[^/]*/|raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/$BRANCH/|g" README.md
+          
+          # Update install.sh
+          sed -i "s|REPO_URL=\"https://raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/[^\"]*\"|REPO_URL=\"https://raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/$BRANCH\"|g" install.sh
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit and push if changed
+        if: steps.check_changes.outputs.changes == 'true'
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add README.md install.sh
+          git commit -m "chore: update repository references to branch ${GITHUB_REF#refs/heads/}"
+          git push

--- a/.github/workflows/update-repo-refs.yml
+++ b/.github/workflows/update-repo-refs.yml
@@ -1,11 +1,15 @@
 name: Update Repository References
 
+# Workflow triggers only when README.md or install.sh are modified
 on:
   push:
     branches:
       - '*'
     tags-ignore:
       - '*'
+    paths:
+      - 'README.md'
+      - 'install.sh'
 
 jobs:
   update-refs:

--- a/.github/workflows/update-repo-refs.yml
+++ b/.github/workflows/update-repo-refs.yml
@@ -24,29 +24,47 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - name: Update repository references
+      - name: Check and update repository references
+        id: check_and_update_repository_references
         run: |
           BRANCH=${GITHUB_REF#refs/heads/}
           REPO_OWNER=$(echo $GITHUB_REPOSITORY | cut -d '/' -f1)
           REPO_NAME=$(echo $GITHUB_REPOSITORY | cut -d '/' -f2)
+          NEEDS_UPDATE=false
           
-          # Update README.md
-          sed -i "s|raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/[^/]*/|raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/$BRANCH/|g" README.md
+          # Check README.md
+          if grep -q "raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/[^/]*/.*" README.md; then
+            CURRENT_BRANCH=$(grep -o "raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/[^/]*/" README.md | head -1 | cut -d'/' -f6)
+            if [ "$CURRENT_BRANCH" != "$BRANCH" ]; then
+              echo "README.md references $CURRENT_BRANCH, updating to $BRANCH"
+              sed -i "s|raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/[^/]*/|raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/$BRANCH/|g" README.md
+              NEEDS_UPDATE=true
+            else
+              echo "README.md already references correct branch: $BRANCH"
+            fi
+          fi
           
-          # Update install.sh
-          sed -i "s|REPO_URL=\"https://raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/[^\"]*\"|REPO_URL=\"https://raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/$BRANCH\"|g" install.sh
-
-      - name: Check for changes
-        id: check_changes
-        run: |
-          if [[ -n "$(git status --porcelain)" ]]; then
-            echo "changes=true" >> $GITHUB_OUTPUT
+          # Check install.sh
+          if grep -q "REPO_URL=\"https://raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/[^\"]*\"" install.sh; then
+            CURRENT_BRANCH=$(grep "REPO_URL=" install.sh | grep -o "/$REPO_OWNER/$REPO_NAME/[^\"]*" | cut -d'/' -f4)
+            if [ "$CURRENT_BRANCH" != "$BRANCH" ]; then
+              echo "install.sh references $CURRENT_BRANCH, updating to $BRANCH"
+              sed -i "s|REPO_URL=\"https://raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/[^\"]*\"|REPO_URL=\"https://raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/$BRANCH\"|g" install.sh
+              NEEDS_UPDATE=true
+            else
+              echo "install.sh already references correct branch: $BRANCH"
+            fi
+          fi
+          
+          # Export result for next steps
+          if [ "$NEEDS_UPDATE" = true ]; then
+            echo "update_needed=true" >> $GITHUB_OUTPUT
           else
-            echo "changes=false" >> $GITHUB_OUTPUT
+            echo "update_needed=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Commit and push if changed
-        if: steps.check_changes.outputs.changes == 'true'
+        if: steps.check_and_update_repository_references.outputs.update_needed == 'true'
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that automatically updates repository references in README.md and install.sh to match the current branch.

### Changes
- Added `.github/workflows/update-repo-refs.yml` workflow file
- Workflow triggers when:
  - A push is made to any branch (except tags)
  - AND it's not made by the GitHub Actions bot (prevents workflow loops)
  - AND either README.md or install.sh were modified
- Intelligently updates repository references in:
  - README.md: curl commands for install.sh and uninstall.sh
  - install.sh: REPO_URL variable
  - Only updates when the current branch references are incorrect
- Changes are committed and pushed by GitHub Actions bot

### How it works
1. When code is pushed to any branch and README.md or install.sh are modified:
   - Workflow checks if the push was made by a developer (not the bot)
   - Checks if the current branch references are incorrect
   - Updates references only if they point to a different branch
   - If changes were made, commits and pushes them back
2. The workflow is optimized to:
   - Prevent infinite loops by skipping bot-made commits
   - Only run when relevant files are modified
   - Only update when branch references are incorrect
   - Ensure branch-specific installations work correctly

This ensures that when someone checks out a specific branch and runs the install script, they get the code from that branch instead of main.